### PR TITLE
remove redundant ARG, add build command to readme, build using nproc processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN cmake \
     -D CMAKE_INSTALL_PREFIX=/opt/RDKit \
     -D CMAKE_BUILD_TYPE=Release \
     . 
-RUN make -j$(nprocs)
+RUN make -j$(nproc)
 
 USER root
 WORKDIR /opt/RDKit-build/rdkit

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
         libboost-system${boost_dev_version}-dev \
         libeigen3-dev \
         libfreetype6-dev \
-        postgresql-server-dev-${postgres_version}=$(postgres -V | awk '{print $3}')\* \
+        postgresql-server-dev-${postgres_version} \
         zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -79,7 +79,6 @@ RUN initdb -D /opt/RDKit-build/pgdata \
   && pg_ctl -D /opt/RDKit-build/pgdata stop
 
 
-ARG postgres_image_version=16.2
 FROM docker.io/postgres:${postgres_image_version}
 ARG postgres_version=16
 ARG boost_version=1.74.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update \
         libboost-system${boost_dev_version}-dev \
         libeigen3-dev \
         libfreetype6-dev \
-        postgresql-server-dev-${postgres_version} \
+        postgresql-server-dev-${postgres_version}=$(postgres -V | awk '{print $3}')\* \
         zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update \
         build-essential \
         cmake \
         git \
+        coreutils \
         libboost-iostreams${boost_dev_version}-dev \
         libboost-regex${boost_dev_version}-dev \
         libboost-serialization${boost_dev_version}-dev \
@@ -62,7 +63,7 @@ RUN cmake \
     -D CMAKE_INSTALL_PREFIX=/opt/RDKit \
     -D CMAKE_BUILD_TYPE=Release \
     . 
-RUN make -j4
+RUN make -j$(nprocs)
 
 USER root
 WORKDIR /opt/RDKit-build/rdkit

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@ postgres-rdkit
 
 This repository provides a Dockerfile for extending the official PostgreSQL debian-based Docker image, with the installation of the RDKit cartridge.
 
+Example command to build the image:
+
+```bash
+docker build -f Dockerfile  --build-arg postgres_image_version="12.17-bullseye" --build-arg postgres_version=12 --build-arg rdkit_git_ref=Release_2023_09_6  --tag rdkit-postgres-12-rdkit_2023_09_6:latest .
+```
+
 For everything related to how to run postgres, you should be able to just refer to the documentation for the [upstream image](https://hub.docker.com/_/postgres).
 
 For everything related to how to use the RDKit cartridge, you can refer to the related [documentation](https://www.rdkit.org/docs/Cartridge.html).


### PR DESCRIPTION
- nproc is used to use all cores on a machine not just 4 to speed up building.
- Add an example to build the image because who remembers all the args and flags
- remove redundant postgres_version arg 